### PR TITLE
Add agency comparison dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import QualityPage from './pages/QualityPage';
 import StrengthWeaknessPage from './pages/StrengthWeaknessPage';
 import LLMAnalysisPage from './pages/LLMAnalysisPage';
 import ProblematicStaysPage from './pages/ProblematicStaysPage';
+import AgencyComparisonPage from './pages/AgencyComparisonPage';
 
 // Import layout components
 import Header from './components/layout/Header';
@@ -30,6 +31,7 @@ const App: React.FC = () => {
             <Route path="/strength-weakness" element={<StrengthWeaknessPage />} />
             <Route path="/llm-analysis" element={<LLMAnalysisPage />} />
             <Route path="/problematic-stays" element={<ProblematicStaysPage />} />
+            <Route path="/agency-comparison" element={<AgencyComparisonPage />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -66,7 +66,7 @@ const Sidebar: React.FC = () => {
               </Link>
             </li>
             <li>
-              <Link 
+              <Link
                 to="/problematic-stays"
                 className={`flex items-center px-4 py-2 rounded-md ${
                   isActive('/problematic-stays') 
@@ -78,6 +78,21 @@ const Sidebar: React.FC = () => {
                   <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
                 </svg>
                 Problemeinsätze
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/agency-comparison"
+                className={`flex items-center px-4 py-2 rounded-md ${
+                  isActive('/agency-comparison')
+                    ? 'bg-primary-50 text-primary-600 dark:bg-primary-900 dark:text-primary-300'
+                    : 'text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700'
+                }`}
+              >
+                <svg className="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M4 3h12v2H4V3zm0 4h12v2H4V7zm0 4h12v2H4v-2zm0 4h12v2H4v-2z" />
+                </svg>
+                Agenturvergleich
               </Link>
             </li>
             <li>

--- a/frontend/src/pages/AgencyComparisonPage.tsx
+++ b/frontend/src/pages/AgencyComparisonPage.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import { useAppStore } from '../store/appStore';
+import apiService from '../services/api';
+import Loading from '../components/common/Loading';
+import ErrorMessage from '../components/common/ErrorMessage';
+
+interface KpiItem {
+  agency_id: string;
+  agency_name: string;
+  start_rate: number;
+  completion_rate: number;
+  early_end_rate: number;
+}
+
+interface ProblemItem {
+  agency_id: string;
+  problematic_percentage: number;
+  cancelled_percentage: number;
+  shortened_percentage: number;
+}
+
+const AgencyComparisonPage: React.FC = () => {
+  const { timePeriod } = useAppStore();
+
+  const [kpiData, setKpiData] = useState<KpiItem[]>([]);
+  const [problemData, setProblemData] = useState<ProblemItem[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const [kpis, probs] = await Promise.all([
+          apiService.getAllAgenciesQuotas(timePeriod),
+          apiService.getProblematicStaysOverview(undefined, timePeriod)
+        ]);
+
+        setKpiData(kpis || []);
+        setProblemData(probs?.data || []);
+      } catch (err) {
+        console.error('Error fetching comparison data:', err);
+        setError('Fehler beim Laden der Daten.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [timePeriod]);
+
+  if (isLoading) {
+    return <Loading message="Vergleichsdaten werden geladen..." />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} retry={() => setIsLoading(true)} />;
+  }
+
+  const mergeData = () => {
+    return kpiData.map(kpi => {
+      const prob = problemData.find(p => p.agency_id === kpi.agency_id);
+      return {
+        ...kpi,
+        problematic_percentage: prob?.problematic_percentage ?? null
+      };
+    });
+  };
+
+  const merged = mergeData();
+
+  const sortBy = (key: keyof typeof merged[0], desc = true) => {
+    return [...merged].sort((a: any, b: any) => {
+      const va = a[key] ?? 0;
+      const vb = b[key] ?? 0;
+      return desc ? vb - va : va - vb;
+    });
+  };
+
+  const top = (arr: any[], key: string, n = 5) => sortBy(key as any, true).slice(0, n);
+  const flop = (arr: any[], key: string, n = 5) => sortBy(key as any, false).slice(0, n);
+
+  const renderList = (items: any[], metric: string) => (
+    <table className="min-w-full mb-6 text-sm">
+      <thead>
+        <tr>
+          <th className="text-left p-2">Agentur</th>
+          <th className="text-right p-2">{metric}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((it, idx) => (
+          <tr key={it.agency_id} className={idx % 2 ? 'bg-gray-50 dark:bg-gray-800' : ''}>
+            <td className="p-2">{it.agency_name}</td>
+            <td className="p-2 text-right">{(it[metric] * 100).toFixed(1)}%</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Großer Agenturvergleich</h1>
+      <p className="text-gray-600 dark:text-gray-300 mb-6">Top und Flop Listen der wichtigsten KPIs</p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">Top 5 Start-Rate</h2>
+          {renderList(top(merged, 'start_rate'), 'start_rate')}
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">Flop 5 Start-Rate</h2>
+          {renderList(flop(merged, 'start_rate'), 'start_rate')}
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">Top 5 Problemquote</h2>
+          {renderList(top(merged, 'problematic_percentage'), 'problematic_percentage')}
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-white">Flop 5 Problemquote</h2>
+          {renderList(flop(merged, 'problematic_percentage'), 'problematic_percentage')}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AgencyComparisonPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -140,6 +140,17 @@ export const apiService = {
     }
   },
 
+  // Quotas (KPIs) aller Agenturen
+  getAllAgenciesQuotas: async (timePeriod: string = 'last_quarter'): Promise<any[]> => {
+    try {
+      const response = await api.post('/kpis/filter', { time_period: timePeriod });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching KPIs for all agencies:', error);
+      return [];
+    }
+  },
+
   getCancellationBeforeArrivalRate: async (id: string, timePeriod: string = 'last_quarter'): Promise<any> => {
     const response = await api.get(`/quotas/${id}/cancellation-before-arrival?time_period=${timePeriod}`);
     return response.data;


### PR DESCRIPTION
## Summary
- add API function to fetch KPIs for all agencies
- create page `AgencyComparisonPage` with top/flop lists
- wire new page into router and sidebar

## Testing
- `pytest -q` *(fails: command not found)*